### PR TITLE
ci(docker): multi-arch (amd64+arm64) image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -41,10 +41,18 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: "lab:latest"
+          driver: cloud
+          endpoint: "drachtio/freeswitch-builder"
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.prepare_tag.outputs.image_id }}:${{ steps.prepare_tag.outputs.version }}
           build-args: |


### PR DESCRIPTION
## What

Makes the Docker image multi-arch (**linux/amd64 + linux/arm64**) so it can run on arm64 Kubernetes clusters (jambonz v11 Helm chart arm64 support).

The `docker-publish.yml` build step was single-arch (no buildx builder → the runner's native amd64 only). This adds a `Set up Docker Buildx` step using **Docker Build Cloud** (`driver: cloud`, `endpoint: drachtio/freeswitch-builder`) and `platforms: linux/amd64,linux/arm64` on the build — matching the established house pattern (`upload-recordings`, `drachtio-server`). Tag/version logic, build-args, and image name are unchanged.

## Notes

- Targets `main` (the v11 line). The `release/v12` branch will be rebased on top afterward.
- Requires the org `DOCKERHUB_*` secrets and access to the `drachtio/freeswitch-builder` Build Cloud endpoint (same as the other jambonz image repos).
- After merge, cut a release tag to publish the tag as a multi-arch image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
